### PR TITLE
Fix duplicate interface in SalaryForm

### DIFF
--- a/src/components/SalaryForm.tsx
+++ b/src/components/SalaryForm.tsx
@@ -461,14 +461,6 @@ interface FieldProps {
   className?: string;
   children: React.ReactNode;
 }
-// --- Field pro, tipado ---
-interface FieldProps {
-  label: string;
-  htmlFor?: string;
-  error?: unknown;
-  className?: string;
-  children: React.ReactNode;
-}
 function Field({ label, htmlFor, error, className = "", children }: FieldProps) {
   return (
     <div className={`flex flex-col gap-1 ${className}`}>


### PR DESCRIPTION
## Summary
- remove extra `FieldProps` interface definition

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684397f014848322a3efa37701e52a27