### PR TITLE
Add zod validation and rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-select": "^5.10.1",
     "react-simple-typewriter": "^5.0.1",
     "recharts": "^2.15.3",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/salary/route.ts
+++ b/src/app/api/salary/route.ts
@@ -1,36 +1,57 @@
 // app/api/salary/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma'; // tu cliente Prisma
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { isRateLimited } from '@/lib/rateLimiter';
+
+const salarySchema = z
+  .object({
+    country: z.string().trim(),
+    role: z.string().trim(),
+    stack: z.array(z.string().trim()),
+    contract: z.string().trim(),
+    seniority: z.string().trim(),
+    amount: z.preprocess((v) => Number(v), z.number().int().positive()),
+    currency: z
+      .string()
+      .trim()
+      .transform((v) => v.toUpperCase()),
+  })
+  .strict();
 
 export async function POST(req: NextRequest) {
-  try {
-    const data = await req.json();
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0] ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
 
-    // Validación básica
-    if (
-      !data.country ||
-      !data.role ||
-      !data.amount ||
-      !data.currency ||
-      !data.stack ||
-      !data.contract ||
-      !data.seniority
-    ) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  if (isRateLimited(ip)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+
+  try {
+    const body = await req.json();
+    const parsed = salarySchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid data', details: parsed.error.flatten() },
+        { status: 400 }
+      );
     }
 
-    // Crear la entrada de salario
+    const data = parsed.data;
+
     const newEntry = await prisma.salaryEntry.create({
       data: {
         country: data.country,
         role: data.role,
-        stack: data.stack, // array de strings
+        stack: data.stack,
         contract: data.contract,
         seniority: data.seniority,
-        amount: Number(data.amount),
+        amount: data.amount,
         currency: data.currency,
-        // source: lo puedes dejar por default ("user") o custom
-      }
+      },
     });
 
     return NextResponse.json(newEntry, { status: 201 });

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -1,0 +1,39 @@
+export type RateLimitInfo = {
+  count: number;
+  lastRequest: number;
+};
+
+const globalForRateLimiter = globalThis as unknown as {
+  rateLimiter?: Map<string, RateLimitInfo>;
+};
+
+const store =
+  globalForRateLimiter.rateLimiter ?? new Map<string, RateLimitInfo>();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForRateLimiter.rateLimiter = store;
+}
+
+const WINDOW = 60_000; // 1 minute
+const LIMIT = 5;
+
+export function isRateLimited(key: string): boolean {
+  const now = Date.now();
+  const info = store.get(key);
+
+  if (!info) {
+    store.set(key, { count: 1, lastRequest: now });
+    return false;
+  }
+
+  if (now - info.lastRequest > WINDOW) {
+    store.set(key, { count: 1, lastRequest: now });
+    return false;
+  }
+
+  info.count += 1;
+  info.lastRequest = now;
+  store.set(key, info);
+
+  return info.count > LIMIT;
+}


### PR DESCRIPTION
## Summary
- use `zod` for schema validation of the salary POST body
- add rate limiter util
- implement validation and rate limiting in salary API route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b158eeec8322954c0d6237b8fc20