### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "jest"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.21.0",
@@ -37,6 +38,13 @@
     "eslint-config-next": "15.3.3",
     "prisma": "^6.9.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.6.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/app/api/salary/route.test.ts
+++ b/src/app/api/salary/route.test.ts
@@ -1,0 +1,36 @@
+import { POST } from './route';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    salaryEntry: {
+      create: jest.fn(async ({ data }) => ({ id: '1', ...data })),
+    },
+  },
+}));
+
+describe('POST /api/salary', () => {
+  it('returns 400 when required fields are missing', async () => {
+    const req = { json: async () => ({}) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it('creates salary entry when data is valid', async () => {
+    const data = {
+      country: 'AR',
+      role: 'Dev',
+      stack: ['TS'],
+      contract: 'FT',
+      seniority: 'Junior',
+      amount: 100,
+      currency: 'USD',
+    };
+    const req = { json: async () => data } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.country).toBe('AR');
+  });
+});

--- a/src/components/__tests__/AddSalaryButton.test.tsx
+++ b/src/components/__tests__/AddSalaryButton.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddSalaryButton } from '../AddSalaryButton';
+
+describe('AddSalaryButton', () => {
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+    render(<AddSalaryButton onClick={handleClick} />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('renders button text', () => {
+    render(<AddSalaryButton onClick={() => {}} />);
+    expect(screen.getByText(/push salary/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest setup with React Testing Library
- test AddSalaryButton component
- test salary API route
- run lint and tests in CI workflow

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b15b85c4832282cf3d77f3bb6695