### PR TITLE
Add error handling

### DIFF
--- a/src/hooks/useSalaryStats.tsx
+++ b/src/hooks/useSalaryStats.tsx
@@ -8,10 +8,11 @@ export default function useSalaryStats(currency: string) {
 
   // Mejor con useEffect sólo si cambia la currency
   useEffect(() => {
-    setLoading(true);
-    fetch(`/api/salaries/stats?currency=${currency}`)
-      .then(res => res.json())
-      .then(data => {
+    async function fetchStats() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/salaries/stats?currency=${currency}`);
+        const data = await res.json();
         if (data.error) {
           setStats(null);
           setError(data.error);
@@ -19,12 +20,14 @@ export default function useSalaryStats(currency: string) {
           setStats(data);
           setError(null);
         }
-      })
-      .catch(() => {
+      } catch {
         setStats(null);
         setError("Error cargando estadísticas");
-      })
-      .finally(() => setLoading(false));
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchStats();
   }, [currency]);
 
   return { stats, loading, error };


### PR DESCRIPTION
## Summary
- add async error handling to salary stats hook
- wrap salary form submission in try/catch and show toast on failure

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847b15b8fc88322ac16deb011d1cdc7