### PR TITLE
Implement API pagination

### DIFF
--- a/src/app/api/salaries/route.ts
+++ b/src/app/api/salaries/route.ts
@@ -1,16 +1,25 @@
 // app/api/salaries/route.ts
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
-export async function GET() {
-    try {
-        const salaries = await prisma.salaryEntry.findMany({
-            orderBy: { createdAt: 'desc' },
-            take: 100,
-        });
-        return NextResponse.json(salaries, { status: 200 });
-    } catch (e) {
-        console.error(e); // <-- Usás la variable y el warning desaparece
-        return NextResponse.json({ error: 'Error creating salary entry' }, { status: 500 });
-    }
+export async function GET(req: NextRequest) {
+  try {
+    const page = parseInt(req.nextUrl.searchParams.get('page') || '1', 10);
+    const pageSize = parseInt(req.nextUrl.searchParams.get('pageSize') || '10', 10);
+    const skip = (page - 1) * pageSize;
+
+    const [total, salaries] = await Promise.all([
+      prisma.salaryEntry.count(),
+      prisma.salaryEntry.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: pageSize,
+        skip,
+      }),
+    ]);
+
+    return NextResponse.json({ salaries, total }, { status: 200 });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: 'Error fetching salary entries' }, { status: 500 });
+  }
 }

--- a/src/components/Salary/SalaryList.tsx
+++ b/src/components/Salary/SalaryList.tsx
@@ -23,6 +23,7 @@ function formatCurrency(amount: number, currency: string) {
 
 export function SalaryList() {
   const [salaries, setSalaries] = useState<Salary[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,10 +47,12 @@ export function SalaryList() {
   useEffect(() => {
     async function fetchSalaries() {
       try {
-        const res = await fetch("/api/salaries");
+        setLoading(true);
+        const res = await fetch(`/api/salaries?page=${page}&pageSize=${pageSize}`);
         if (!res.ok) throw new Error("No se pudo obtener los salarios");
         const data = await res.json();
-        setSalaries(data);
+        setSalaries(data.salaries);
+        setTotal(data.total);
       } catch {
         setError("Error desconocido");
       } finally {
@@ -57,7 +60,7 @@ export function SalaryList() {
       }
     }
     fetchSalaries();
-  }, []);
+  }, [page]);
 
   // --- Logic ---
   const filtered = useMemo(() => {
@@ -69,8 +72,8 @@ export function SalaryList() {
     );
   }, [salaries, country, role, seniority, currency]);
 
-  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
-  const paged = filtered.slice((page - 1) * pageSize, page * pageSize);
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const paged = filtered;
   const uniqueCountries = useMemo(() => Array.from(new Set(salaries.map(s => s.country))).sort(), [salaries]);
   const uniqueRoles = useMemo(() => Array.from(new Set(salaries.map(s => s.role))).sort(), [salaries]);
   const uniqueCurrencies = useMemo(() => Array.from(new Set(salaries.map(s => s.currency))).sort(), [salaries]);


### PR DESCRIPTION
## Summary
- support `page` and `pageSize` in `/api/salaries`
- request paginated salary data from `SalaryList`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b15c0748832290a98adef8a354b3