### PR TITLE
Add API and form tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run lint
-      - run: npm test
+      - run: npm test -- --runInBand

--- a/src/app/api/salaries/route.test.ts
+++ b/src/app/api/salaries/route.test.ts
@@ -1,0 +1,54 @@
+import { GET } from './route';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    salaryEntry: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+describe('GET /api/salaries', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('paginates results based on page and pageSize', async () => {
+    (prisma.salaryEntry.count as jest.Mock).mockResolvedValue(5);
+    (prisma.salaryEntry.findMany as jest.Mock).mockResolvedValue([
+      { id: '3' },
+      { id: '2' },
+    ]);
+
+    const req = {
+      nextUrl: { searchParams: new URLSearchParams('page=2&pageSize=2') },
+    } as any;
+
+    const res = await GET(req);
+    expect(prisma.salaryEntry.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: 'desc' },
+      take: 2,
+      skip: 2,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(5);
+    expect(body.salaries).toHaveLength(2);
+  });
+
+  it('returns 500 for invalid parameters', async () => {
+    (prisma.salaryEntry.count as jest.Mock).mockResolvedValue(0);
+    (prisma.salaryEntry.findMany as jest.Mock).mockRejectedValue(new Error('bad'));
+
+    const req = {
+      nextUrl: { searchParams: new URLSearchParams('page=foo&pageSize=bar') },
+    } as any;
+
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+});

--- a/src/components/__tests__/SalaryForm.test.tsx
+++ b/src/components/__tests__/SalaryForm.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SalaryForm from '../SalaryForm';
+
+describe('SalaryForm', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const fillForm = () => {
+    fireEvent.change(screen.getByLabelText('País'), { target: { value: 'AR' } });
+    fireEvent.change(screen.getByLabelText('Rol'), { target: { value: 'Dev' } });
+    fireEvent.change(screen.getByLabelText('Tipo de contrato'), { target: { value: 'Full-time' } });
+    fireEvent.change(screen.getByLabelText('Seniority'), { target: { value: 'Junior' } });
+    fireEvent.change(screen.getByLabelText('Monto mensual'), { target: { value: '1000' } });
+    fireEvent.change(screen.getByLabelText('Moneda'), { target: { value: 'USD' } });
+  };
+
+  it('shows success message on successful submit', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    render(<SalaryForm />);
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: /enviar salario/i }));
+
+    expect(global.fetch).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText(/salario enviado/i)).toBeInTheDocument());
+  });
+
+  it('shows error message on failed submit', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    render(<SalaryForm />);
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: /enviar salario/i }));
+
+    expect(global.fetch).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText(/hubo un error/i)).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for salaries API
- test SalaryForm submit success and error
- run Jest in CI

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68486abf6ab88322bfd468603d1d8e76