### PR TITLE
Improve API validation and Redis rate limiting

### DIFF
--- a/src/app/api/salary/route.test.ts
+++ b/src/app/api/salary/route.test.ts
@@ -8,6 +8,10 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
+jest.mock('@/lib/rateLimiter', () => ({
+  isRateLimited: jest.fn(async () => false),
+}));
+
 describe('POST /api/salary', () => {
   it('returns 400 when required fields are missing', async () => {
     const req = { json: async () => ({}) } as any;
@@ -34,3 +38,4 @@ describe('POST /api/salary', () => {
     expect(body.country).toBe('AR');
   });
 });
+

--- a/src/app/api/salary/route.ts
+++ b/src/app/api/salary/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
     req.headers.get('x-real-ip') ||
     'unknown';
 
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(ip)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 
@@ -60,3 +60,4 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
 }
+


### PR DESCRIPTION
## Summary
- validate pagination parameters in `/api/salaries` endpoint
- implement Upstash-based Redis rate limiter
- update salary POST endpoint to await new rate limiter
- mock rate limiter in POST unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684870b0d94c8322a023a4e8b3dbc73f