### PR TITLE
Add Prettier and docs update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
+# PostgreSQL connection string
 DATABASE_URL="postgresql://USER:PASS@localhost:5432/dbname"
+
+# Data store for rate limiter, e.g. Redis URL or "memory"
+RATE_LIMIT_STORE="memory"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+public
+.next

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 🇬🇧 About SalaryBoard
+
+**SalaryBoard** is an open-source platform where tech workers can share and view salaries anonymously. Browse by country, role or seniority and contribute your own data without sign ups.
+
+---
+
 ## 🚀 ¿Qué es SalaryBoard?
 
 **SalaryBoard** es una plataforma open-source para consultar y compartir salarios del sector tech.  
@@ -79,10 +85,27 @@ npm run dev
 
 Abrí <http://localhost:3000> en tu navegador para verificar que todo funcione.
 
+## ✅ Tests
+
+Para ejecutar la suite de pruebas:
+
+```bash
+npm test
+```
+
+## Commands
+
+- `npm run dev` – entorno de desarrollo
+- `npm run build` – compilar la aplicación
+- `npm start` – iniciar la versión compilada
+- `npm test` – correr tests
+- `npm run lint` – ejecutar ESLint
+- `npm run format` – formatear con Prettier
+
 ## Observaciones y mejoras pendientes
 
 - Eliminar rutas de depuración o protegerlas con autenticación.
-- Crear archivo `.env.example` con las variables requeridas.
-- Agregar configuración de Tailwind (`tailwind.config.ts`).
+- Crear archivo `.env.example` con las variables requeridas. ✅
+- Agregar configuración de Tailwind (`tailwind.config.ts`). ✅
 - Validar y limitar las peticiones a la API.
 - Incluir tests y flujo de CI para lint y pruebas.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "prettier --write .",
     "postinstall": "prisma generate",
     "test": "jest"
   },
@@ -46,6 +47,7 @@
     "jest-environment-jsdom": "^29.6.0",
     "@testing-library/react": "^14.1.0",
     "@testing-library/jest-dom": "^6.1.0",
-    "@testing-library/user-event": "^14.4.3"
+    "@testing-library/user-event": "^14.4.3",
+    "prettier": "^3.2.5"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,11 +1,21 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-space-grotesk)', 'sans-serif'],
+        mono: ['var(--font-ibm-mono)', 'monospace'],
+        serif: ['EB Garamond', 'serif'],
+      },
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+    },
   },
   plugins: [],
-}
+};
 
-export default config
+export default config;


### PR DESCRIPTION
## Summary
- list environment variables in `.env.example`
- add Prettier config and format script
- extend Tailwind theme with fonts and colors
- update README with English intro, commands, and test instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684870b433948322adad384364d5ceda