### PR TITLE
Add next-intl for localized UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-awesome-reveal": "^4.3.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.57.0",
+    "next-intl": "^3.2.0",
     "react-icons": "^5.5.0",
     "react-select": "^5.10.1",
     "react-simple-typewriter": "^5.0.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@
 import { Space_Grotesk, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import Footer from "@/components/Footer";
+import { NextIntlClientProvider } from "next-intl";
+import esMessages from "../i18n/es.json";
 
 
 export const metadata = {
@@ -49,8 +51,10 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body className={`${spaceGrotesk.variable} ${ibmMono.variable} antialiased`}>
-        <main className="min-h-screen bg-black/90 text-white font-sans">{children}</main>
-        <Footer />
+        <NextIntlClientProvider locale="es" messages={esMessages}>
+          <main className="min-h-screen bg-black/90 text-white font-sans">{children}</main>
+          <Footer />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/Modal";
 import Squares from "@/components/Squares/Squares";
 import Faq from "@/components/Faq";
 import Hero from "@/components/Hero";
+import { useTranslations } from "next-intl";
 
 // Easter egg para consola dev
 if (typeof window !== "undefined") {
@@ -21,6 +22,7 @@ if (typeof window !== "undefined") {
 
 export default function HomePage() {
   const [showForm, setShowForm] = useState(false);
+  const t = useTranslations();
 
   return (
     <main className="min-h-screen text-white font-sans antialiased pb-8">
@@ -51,7 +53,7 @@ export default function HomePage() {
             transition={{ duration: 0.21 }}
           >
             <Modal open={showForm} onClose={() => setShowForm(false)}>
-              <h2 className="text-xl font-black text-gray-100 mb-2 text-left">Ingresá tu salario</h2>
+              <h2 className="text-xl font-black text-gray-100 mb-2 text-left">{t('modal.title')}</h2>
               <p className="text-sm text-gray-500 mb-4 font-mono">
                 <span className="text-teal-300">No logs, no tracking.</span>
               </p>
@@ -59,7 +61,7 @@ export default function HomePage() {
               <p className="text-xs mt-4 text-gray-700 font-mono">
                 {/* hint de geek UX */}
                 {/* tip: Proba <kbd>Ctrl+K</kbd> o <kbd>⌘+K</kbd> para buscar roles más rápido */}
-                Tip: <kbd>Ctrl+K</kbd> para buscar roles rápido.
+                {t.raw('modal.tip')}
               </p>
             </Modal>
           </motion.div>
@@ -68,9 +70,9 @@ export default function HomePage() {
 
       {/* DATA */}
       <section id="opendata" className="max-w-6xl mx-auto px-4">
-        <h2 className="text-2xl font-black text-gray-200 mb-3 mt-16 text-left font-mono">$ open data</h2>
+        <h2 className="text-2xl font-black text-gray-200 mb-3 mt-16 text-left font-mono">{t('openData.heading')}</h2>
         <p className="text-base text-gray-500 mb-8 text-left font-mono">
-          Consultá salarios, filtrá por país, rol o seniority y mirá tendencias reales del mercado.
+          {t('openData.description')}
         </p>
         <div className="border border-white/10 p-6 md:p-10 rounded-none bg-[#0e0e11]/70 backdrop-blur-md shadow-lg">
           <SalaryList />

--- a/src/components/AddSalaryButton.tsx
+++ b/src/components/AddSalaryButton.tsx
@@ -1,13 +1,16 @@
 import { motion } from "framer-motion";
 import { UploadCloud } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 // (No te olvides del shimmer del ejemplo anterior en el CSS global)
 
 export function AddSalaryButton({ onClick }: { onClick: () => void }) {
+  const t = useTranslations("buttons");
   return (
     <motion.button
       onClick={onClick}
       type="button"
+      aria-label={t("addSalary")}
       className={`
         group relative flex items-center justify-center gap-3
         w-full md:w-auto
@@ -61,7 +64,7 @@ export function AddSalaryButton({ onClick }: { onClick: () => void }) {
 
       <UploadCloud size={26} className="text-white drop-shadow-sm md:text-white" />
       <span className="relative z-20 drop-shadow text-base md:text-sm font-bold">
-        push salary
+        {t("addSalary")}
       </span>
     </motion.button>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,10 +8,12 @@ import { AddSalaryButton } from "@/components/AddSalaryButton";
 import { StatsRow } from "./StatsRow";
 import useSalaryStats from "@/hooks/useSalaryStats";
 import { ViewDataButton } from "./ViewDataButton";
+import { useTranslations } from "next-intl";
 
 export default function Hero({ onAddSalary }: { onAddSalary: () => void }) {
   const [selectedCurrency, setSelectedCurrency] = useState("USD");
   const { stats, loading, error } = useSalaryStats(selectedCurrency);
+  const t = useTranslations();
 
   // Scroll smooth a la sección de datos
   const handleScrollToData = () => {
@@ -55,7 +57,7 @@ export default function Hero({ onAddSalary }: { onAddSalary: () => void }) {
       >
         <span className="text-teal-300 text-md font-bold mr-2">$</span>
         <span className="text-white/90">
-          No login, no drama. Solo data, directo de devs reales.
+          {t('hero.noDrama')}
         </span>
         <br />
         <span className="block mt-2">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -28,6 +28,8 @@ export function Modal({ open, onClose, children }: ModalProps) {
       ref={ref}
       className="fixed inset-0 z-50 bg-black/90 backdrop-blur flex items-center justify-center"
       onMouseDown={handleBackdrop}
+      role="dialog"
+      aria-modal="true"
     >
       <div className="relative w-full max-w-2xl p-0 m-4">
         {/* Cerrar */}

--- a/src/components/Salary/ChartTabs.tsx
+++ b/src/components/Salary/ChartTabs.tsx
@@ -2,6 +2,7 @@ import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, PieChart, Pie, Cell, Legend
 } from "recharts";
 import { SeniorityDist } from "./types";
+import { useTranslations } from "next-intl";
 
 const COLORS = ["#14b8a6", "#60a5fa", "#eab308", "#f472b6", "#f87171", "#4ade80", "#a78bfa", "#facc15"];
 
@@ -17,9 +18,9 @@ interface AvgCountry {
 }
 
 const chartTabs = [
-  { key: "role", label: "Promedio por Rol" },
-  { key: "country", label: "Promedio por País" },
-  { key: "seniority", label: "Distribución Seniority" },
+  { key: "role", labelKey: "charts.avgByRole" },
+  { key: "country", labelKey: "charts.avgByCountry" },
+  { key: "seniority", labelKey: "charts.seniorityDist" },
 ] as const;
 
 type TabKey = typeof chartTabs[number]["key"];
@@ -46,17 +47,18 @@ function CustomBarChart({
   barColor: string;
   currency: string;
 }) {
+  const t = useTranslations();
   if (!currency) {
     return (
       <div className="flex flex-1 items-center justify-center text-center text-gray-500 font-bold text-lg">
-        Seleccioná una moneda para ver los promedios salariales.
+        {t("charts.selectCurrency")}
       </div>
     );
   }
   if (!data.length) {
     return (
       <div className="flex flex-1 items-center justify-center text-center text-gray-500 font-bold text-lg">
-        No hay datos para mostrar.
+        {t("charts.noData")}
       </div>
     );
   }
@@ -82,16 +84,17 @@ function CustomBarChart({
 }
 
 function SeniorityChart({ data }: { data: SeniorityDist[] }) {
+  const t = useTranslations();
   if (!data.length) {
     return (
       <div className="flex flex-1 items-center justify-center text-center text-gray-500 font-bold text-lg">
-        No hay datos de seniority.
+        {t('charts.noSeniority')}
       </div>
     );
   }
   return (
     <>
-      <h3 className="font-bold mb-2 text-gray-200 text-center uppercase text-sm tracking-widest">Distribución de seniorities</h3>
+      <h3 className="font-bold mb-2 text-gray-200 text-center uppercase text-sm tracking-widest">{t('charts.seniorityDist')}</h3>
       <ResponsiveContainer width="100%" height={260}>
         <PieChart>
           <Pie data={data} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={90} label>
@@ -118,6 +121,7 @@ export function ChartTabs({
   seniorityDist,
   currency,
 }: ChartTabsProps) {
+  const t = useTranslations();
   return (
     <div className="w-full flex flex-col gap-3 mt-8">
       {/* Tabs */}
@@ -132,7 +136,7 @@ export function ChartTabs({
                 : "border-transparent text-gray-500 hover:text-teal-400"}`}
             style={{ fontSize: 15, background: "none" }}
           >
-            {tab.label}
+            {t(tab.labelKey)}
           </button>
         ))}
       </div>
@@ -142,7 +146,7 @@ export function ChartTabs({
           <CustomBarChart
             data={avgPerRole}
             xKey="role"
-            label="Promedio salarial por Rol"
+            label={t('charts.avgByRole')}
             barColor="#14b8a6"
             currency={currency}
           />
@@ -151,7 +155,7 @@ export function ChartTabs({
           <CustomBarChart
             data={avgPerCountry}
             xKey="country"
-            label="Promedio salarial por País"
+            label={t('charts.avgByCountry')}
             barColor="#60a5fa"
             currency={currency}
           />

--- a/src/components/Salary/SalariesTable.tsx
+++ b/src/components/Salary/SalariesTable.tsx
@@ -1,5 +1,6 @@
 // components/Salary/SalariesTable.tsx
 import { Salary } from "./types";
+import { useTranslations } from "next-intl";
 
 interface SalariesTableProps {
   paged: Salary[];
@@ -16,13 +17,14 @@ export function SalariesTable({
   setPage,
   formatCurrency,
 }: SalariesTableProps) {
+  const t = useTranslations();
   return (
     <div className="w-full">
 
       {/* Mobile: Cards */}
       <div className="md:hidden flex flex-col gap-3 mt-2">
         {paged.length === 0 && (
-          <div className="text-center text-gray-400 text-base py-6">No hay salarios aún.</div>
+          <div className="text-center text-gray-400 text-base py-6">{t('messages.noData')}</div>
         )}
         {paged.map((s) => (
           <div
@@ -53,13 +55,13 @@ export function SalariesTable({
           <table className="min-w-full text-sm font-normal backdrop-blur-2xl bg-black/80 border-separate border-spacing-0">
             <thead>
               <tr className="sticky items-start top-0 z-20 bg-black/80 backdrop-blur-xl border-b border-white/10">
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">País</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Rol</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Stack</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Contrato</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Seniority</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Salario</th>
-                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">Fecha</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.country')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.role')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.stack')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.contract')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.seniority')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.salary')}</th>
+                <th className="px-auto text-start py-3 text-xs text-gray-300 font-bold">{t('table.date')}</th>
               </tr>
             </thead>
             <tbody>
@@ -90,9 +92,9 @@ export function SalariesTable({
       {/* Pagination (compartida) */}
       {pageCount > 1 && (
         <div className="flex justify-center items-center gap-2 py-5">
-          <button disabled={page === 1} onClick={() => setPage(page - 1)} className="px-3 py-1 rounded-none bg-[#18181b] text-gray-400 border border-white/10 hover:text-white hover:border-teal-400 disabled:opacity-50 text-xs font-semibold transition">Anterior</button>
+          <button disabled={page === 1} onClick={() => setPage(page - 1)} className="px-3 py-1 rounded-none bg-[#18181b] text-gray-400 border border-white/10 hover:text-white hover:border-teal-400 disabled:opacity-50 text-xs font-semibold transition">{t('table.prev')}</button>
           <span className="text-xs px-2">{page}/{pageCount}</span>
-          <button disabled={page === pageCount} onClick={() => setPage(page + 1)} className="px-3 py-1 rounded-none bg-[#18181b] text-gray-400 border border-white/10 hover:text-white hover:border-teal-400 disabled:opacity-50 text-xs font-semibold transition">Siguiente</button>
+          <button disabled={page === pageCount} onClick={() => setPage(page + 1)} className="px-3 py-1 rounded-none bg-[#18181b] text-gray-400 border border-white/10 hover:text-white hover:border-teal-400 disabled:opacity-50 text-xs font-semibold transition">{t('table.next')}</button>
         </div>
       )}
     </div>

--- a/src/components/Salary/SalaryList.tsx
+++ b/src/components/Salary/SalaryList.tsx
@@ -5,6 +5,7 @@ import { FiltersBar } from "./FiltersBar";
 import { SalariesTable } from "./SalariesTable";
 import { ChartTabs } from "./ChartTabs";
 import { Salary } from "./types";
+import { useTranslations } from "next-intl";
 
 const SENIORITIES = ["Junior", "Mid", "Senior", "Lead"];
 
@@ -26,6 +27,7 @@ export function SalaryList() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const t = useTranslations();
 
   // Filtros
   const [country, setCountry] = useState("");
@@ -49,12 +51,12 @@ export function SalaryList() {
       try {
         setLoading(true);
         const res = await fetch(`/api/salaries?page=${page}&pageSize=${pageSize}`);
-        if (!res.ok) throw new Error("No se pudo obtener los salarios");
+        if (!res.ok) throw new Error(t('messages.error'));
         const data = await res.json();
         setSalaries(data.salaries);
         setTotal(data.total);
       } catch {
-        setError("Error desconocido");
+        setError(t('messages.error'));
       } finally {
         setLoading(false);
       }
@@ -131,9 +133,9 @@ export function SalaryList() {
   }, [filtered]);
 
   // --- UI ---
-  if (loading) return <p className="text-center text-gray-400">Cargando...</p>;
+  if (loading) return <p className="text-center text-gray-400">{t('messages.loading')}</p>;
   if (error) return <p className="text-center text-red-500">{error}</p>;
-  if (salaries.length === 0) return <p className="text-center text-gray-400">No hay salarios aún.</p>;
+  if (salaries.length === 0) return <p className="text-center text-gray-400">{t('messages.noData')}</p>;
 
   return (
     <section className="font-sans space-y-10 px-2 sm:px-4 md:px-0">
@@ -153,7 +155,7 @@ export function SalaryList() {
                 {filtered.length}
               </motion.span>
               <span className="text-[13px] md:text-sm uppercase text-gray-500 font-semibold tracking-wide mt-1">
-                Registros
+                {t('messages.records')}
               </span>
             </div>
             {/* Promedio */}
@@ -168,7 +170,7 @@ export function SalaryList() {
                 {formatCurrency(avgAmount, topCurrency)}
               </motion.span>
               <span className="text-xl md:text-sm uppercase text-gray-500 font-semibold tracking-wide mt-1">
-                Promedio
+                {t('stats.avg')}
               </span>
             </div>
           </div>

--- a/src/components/StatsRow.tsx
+++ b/src/components/StatsRow.tsx
@@ -1,6 +1,7 @@
 // components/StatsRow.tsx
 import { CurrencyDropdown } from "./CurrencyDropdown";
 import { Stat } from "./Stat";
+import { useTranslations } from "next-intl";
 
 interface StatsRowProps {
   stats: { total: number; avg: number; currency: string } | null;
@@ -17,6 +18,7 @@ export function StatsRow({
   selectedCurrency,
   setSelectedCurrency,
 }: StatsRowProps) {
+  const t = useTranslations();
   return (
     <div className="w-full flex flex-col-reverse md:flex-row-reverse md:items-start md:justify-between gap-6 md:gap-0">
       <div className="flex items-center gap-2">
@@ -32,11 +34,11 @@ export function StatsRow({
           <span className="text-red-400 text-sm">{error}</span>
         ) : stats ? (
           <>
-            <Stat label="Salarios cargados" value={stats.total.toLocaleString()} />
-            <Stat label="Salario promedio" value={`${stats.avg.toLocaleString()} ${stats.currency}`} />
+            <Stat label={t("stats.loaded")} value={stats.total.toLocaleString()} />
+            <Stat label={t("stats.avg")} value={`${stats.avg.toLocaleString()} ${stats.currency}`} />
           </>
         ) : (
-          <span className="text-red-400 text-sm">No hay stats</span>
+          <span className="text-red-400 text-sm">{t("stats.noStats")}</span>
         )}
       </div>
     </div>

--- a/src/components/ViewDataButton.tsx
+++ b/src/components/ViewDataButton.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function ViewDataButton({ onClick }: { onClick: () => void }) {
   const [hovered, setHovered] = React.useState(false);
+  const t = useTranslations("buttons");
 
   return (
     <motion.button
       onClick={onClick}
       type="button"
+      aria-label={t("viewData")}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={`
@@ -36,7 +39,7 @@ export function ViewDataButton({ onClick }: { onClick: () => void }) {
       transition={{ delay: 0.16, duration: 0.36, type: "spring" }}
     >
       <span className="relative z-20 drop-shadow text-base md:text-sm font-bold">
-query salarios
+        {t("viewData")}
       </span>
       <AnimatePresence>
         {hovered && (

--- a/src/components/__tests__/AddSalaryButton.test.tsx
+++ b/src/components/__tests__/AddSalaryButton.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AddSalaryButton } from '../AddSalaryButton';
+import { NextIntlProvider } from 'next-intl';
+import messages from '../../i18n/en.json';
 
 describe('AddSalaryButton', () => {
   it('calls onClick when clicked', () => {
@@ -11,7 +13,11 @@ describe('AddSalaryButton', () => {
   });
 
   it('renders button text', () => {
-    render(<AddSalaryButton onClick={() => {}} />);
-    expect(screen.getByText(/push salary/i)).toBeInTheDocument();
+    render(
+      <NextIntlProvider messages={messages} locale="en">
+        <AddSalaryButton onClick={() => {}} />
+      </NextIntlProvider>
+    );
+    expect(screen.getByText(messages.buttons.addSalary)).toBeInTheDocument();
   });
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,47 @@
+{
+  "buttons": {
+    "addSalary": "push salary",
+    "viewData": "query salaries"
+  },
+  "hero": {
+    "noDrama": "No login, no drama. Just real dev data."
+  },
+  "openData": {
+    "heading": "$ open data",
+    "description": "Browse salaries, filter by country, role or seniority and see real market trends."
+  },
+  "modal": {
+    "title": "Enter your salary",
+    "tip": "Tip: <kbd>Ctrl+K</kbd> to quickly search roles."
+  },
+  "stats": {
+    "loaded": "Salaries loaded",
+    "avg": "Average salary",
+    "noStats": "No stats"
+  },
+  "messages": {
+    "loading": "Loading...",
+    "noData": "No salaries yet.",
+    "error": "Unknown error",
+    "records": "Records"
+  },
+  "charts": {
+    "avgByRole": "Average salary by Role",
+    "avgByCountry": "Average salary by Country",
+    "seniorityDist": "Seniority distribution",
+    "selectCurrency": "Select a currency to view salary averages.",
+    "noData": "No data to display.",
+    "noSeniority": "No seniority data."
+  },
+  "table": {
+    "country": "Country",
+    "role": "Role",
+    "stack": "Stack",
+    "contract": "Contract",
+    "seniority": "Seniority",
+    "salary": "Salary",
+    "date": "Date",
+    "prev": "Previous",
+    "next": "Next"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,47 @@
+{
+  "buttons": {
+    "addSalary": "push salary",
+    "viewData": "query salarios"
+  },
+  "hero": {
+    "noDrama": "No login, no drama. Solo data, directo de devs reales."
+  },
+  "openData": {
+    "heading": "$ open data",
+    "description": "Consultá salarios, filtrá por país, rol o seniority y mirá tendencias reales del mercado."
+  },
+  "modal": {
+    "title": "Ingresá tu salario",
+    "tip": "Tip: <kbd>Ctrl+K</kbd> para buscar roles rápido."
+  },
+  "stats": {
+    "loaded": "Salarios cargados",
+    "avg": "Salario promedio",
+    "noStats": "No hay stats"
+  },
+  "messages": {
+    "loading": "Cargando...",
+    "noData": "No hay salarios aún.",
+    "error": "Error desconocido",
+    "records": "Registros"
+  },
+  "charts": {
+    "avgByRole": "Promedio salarial por Rol",
+    "avgByCountry": "Promedio salarial por País",
+    "seniorityDist": "Distribución de seniorities",
+    "selectCurrency": "Seleccioná una moneda para ver los promedios salariales.",
+    "noData": "No hay datos para mostrar.",
+    "noSeniority": "No hay datos de seniority."
+  },
+  "table": {
+    "country": "País",
+    "role": "Rol",
+    "stack": "Stack",
+    "contract": "Contrato",
+    "seniority": "Seniority",
+    "salary": "Salario",
+    "date": "Fecha",
+    "prev": "Anterior",
+    "next": "Siguiente"
+  }
+}


### PR DESCRIPTION
## Summary
- integrate `next-intl` and add locale files
- wrap layout with `NextIntlClientProvider`
- replace key UI strings with translations
- improve accessibility on modal and buttons
- update unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684870beb7f4832286db700096c652fd