### PR TITLE
Update README and env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # PostgreSQL connection string
 DATABASE_URL="postgresql://USER:PASS@localhost:5432/dbname"
-# Optional Redis connection for rate limiting
-# REDIS_URL="redis://localhost:6379"
-# RATE_LIMIT_WINDOW="60000"
-# RATE_LIMIT_LIMIT="5"
+# Upstash Redis connection for rate limiting (optional)
+# Provide these to enable global rate limits
+UPSTASH_REDIS_REST_URL=""
+UPSTASH_REDIS_REST_TOKEN=""
+# Window in seconds and max requests
+RATE_LIMIT_WINDOW="60"
+RATE_LIMIT_LIMIT="5"

--- a/README.md
+++ b/README.md
@@ -87,19 +87,43 @@ npm run dev
 
 Seguí los pasos anteriores para levantar el proyecto en modo desarrollo. Una vez en marcha, visita `http://localhost:3000` para ver la app.
 
+## 🐳 Docker
+
+También podés levantar la app con Docker:
+
+```bash
+docker build -t salaryboard .
+docker run --env-file .env -p 3000:3000 salaryboard
+```
+
+Si contás con **Docker Compose**, basta con:
+
+```bash
+docker compose up --build
+```
+
 ## 🔧 Variables de entorno
 
-Crea un archivo `.env` con al menos la siguiente variable:
+Crea un archivo `.env` con las siguientes variables básicas:
 
 ```
 DATABASE_URL=postgresql://usuario:password@localhost:5432/salaryscope
+# Opcional: habilitar rate limit con Upstash
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+RATE_LIMIT_WINDOW=60
+RATE_LIMIT_LIMIT=5
 ```
 
 Ajusta los valores según tu configuración local o remota.
 
 ## 🧪 Ejecutar pruebas
 
-El proyecto no cuenta aún con una suite de tests automatizados. Puedes ejecutar `npm run lint` para revisar el código y asegurarte de que la base de datos esté configurada correctamente con `npx prisma generate`.
+El proyecto incluye pruebas unitarias con **Jest** y Testing Library.
+
+```bash
+npm test
+```
 
 ## 🙌 Contribuir
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/user-event": "^14.4.3",
     "prettier": "^3.2.5"
+  },
+  "lint-staged": {
+    "*.{js,ts,tsx}": ["prettier --write", "eslint --fix"],
+    "*.{md,css,scss}": ["prettier --write"]
   }
 }


### PR DESCRIPTION
## Summary
- document Upstash environment variables in example file
- add lint-staged config and instructions for running tests and Docker usage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488581a0dc83228933461885f58e5b