### PR TITLE
Configure rate limit via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # PostgreSQL connection string
 DATABASE_URL="postgresql://USER:PASS@localhost:5432/dbname"
-# Optional Redis connection for rate limiting
-# REDIS_URL="redis://localhost:6379"
-# RATE_LIMIT_WINDOW="60000"
+# Optional Upstash REST connection for rate limiting
+# UPSTASH_REDIS_REST_URL="https://<unique-id>.upstash.io"
+# UPSTASH_REDIS_REST_TOKEN="<token>"
+# RATE_LIMIT_WINDOW="60" # seconds
 # RATE_LIMIT_LIMIT="5"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ DATABASE_URL=postgresql://usuario:password@localhost:5432/salaryscope
 
 Ajusta los valores según tu configuración local o remota.
 
+Para habilitar el limitador de tasa opcional define también:
+
+```
+UPSTASH_REDIS_REST_URL=https://<id>.upstash.io
+UPSTASH_REDIS_REST_TOKEN=<token>
+RATE_LIMIT_WINDOW=60
+RATE_LIMIT_LIMIT=5
+```
+
 ## 🧪 Ejecutar pruebas
 
 El proyecto no cuenta aún con una suite de tests automatizados. Puedes ejecutar `npm run lint` para revisar el código y asegurarte de que la base de datos esté configurada correctamente con `npx prisma generate`.

--- a/src/lib/rateLimiter.ts
+++ b/src/lib/rateLimiter.ts
@@ -1,8 +1,10 @@
 const URL = process.env.UPSTASH_REDIS_REST_URL;
 const TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-const WINDOW = 60; // seconds
-const LIMIT = 5;
+// Window duration and request limit for the rate limiter.
+// Values are read from environment variables and fall back to sensible defaults.
+const WINDOW = Number(process.env.RATE_LIMIT_WINDOW ?? '60'); // seconds
+const LIMIT = Number(process.env.RATE_LIMIT_LIMIT ?? '5');
 
 async function incr(key: string): Promise<number> {
   if (!URL || !TOKEN) {


### PR DESCRIPTION
## Summary
- let rate limiter be configured with `RATE_LIMIT_WINDOW` and `RATE_LIMIT_LIMIT`
- document optional Upstash env vars and rate limit defaults

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848931658e48322887d8e71092e5cda